### PR TITLE
Added automatic symlinking for mods

### DIFF
--- a/server/steamcmd/server_start
+++ b/server/steamcmd/server_start
@@ -7,6 +7,8 @@ sed -i "s/PASSWORD/${STEAM_PASSWORD}/g" /server/steamcmd/starbound_update.txt
 # Update the server on start
 /server/steamcmd/steamcmd.sh +runscript starbound_update.txt
 
+# Modified version of this script: https://www.youtube.com/watch?v=LwDQaye2TZs
+
 # Cleaning the mods folder
 rm /server/steamcmd/starbound/mods/*.pak
 rmdir --ignore-fail-on-non-empty ./starbound/steamapps/workshop/content/211820/*

--- a/server/steamcmd/server_start
+++ b/server/steamcmd/server_start
@@ -7,6 +7,18 @@ sed -i "s/PASSWORD/${STEAM_PASSWORD}/g" /server/steamcmd/starbound_update.txt
 # Update the server on start
 /server/steamcmd/steamcmd.sh +runscript starbound_update.txt
 
+# Cleaning the mods folder
+rm /server/steamcmd/starbound/mods/*.pak
+rmdir --ignore-fail-on-non-empty ./starbound/steamapps/workshop/content/211820/*
+ 
+# Creating a symlink for every .pak file in the workshop folder to the mods folder
+for dir in /server/steamcmd/starbound/steamapps/workshop/content/211820/*/
+do
+ dir=${dir%*/}
+ echo Sym-linking mod ${dir##*/} into the mods folder
+ ln -r -s /server/steamcmd/starbound/steamapps/workshop/content/211820/${dir##*/}/*.pak /server/steamcmd/starbound/mods/${dir##*/}.pak
+done
+
 # Run the starbound server
 cd /server/steamcmd/starbound/linux
 ./starbound_server


### PR DESCRIPTION
This change will symlink the downloaded mods from the steamcmd to the mod folder of the starbound server. Now at every startup it will update all the mods which the used steam account hads added to his game trough workshop automatically to the server.